### PR TITLE
Minor comment change for redirect URIs

### DIFF
--- a/lib/msal-browser/src/app/PublicClientApplication.ts
+++ b/lib/msal-browser/src/app/PublicClientApplication.ts
@@ -472,7 +472,6 @@ export class PublicClientApplication implements IPublicClientApplication {
     /**
      *
      * Use to get the redirect uri configured in MSAL or null.
-     * Evaluates redirectUri if its a function, otherwise simply returns its value.
      * @returns {string} redirect URL
      *
      */
@@ -482,7 +481,6 @@ export class PublicClientApplication implements IPublicClientApplication {
 
     /**
      * Use to get the post logout redirect uri configured in MSAL or null.
-     * Evaluates postLogoutredirectUri if its a function, otherwise simply returns its value.
      *
      * @returns {string} post logout redirect URL
      */


### PR DESCRIPTION
Particularly as this is a change from MSAL 1.x functionality, this removes two out-dated comments indicating that redirectUri and postLogoutRedirectUri can be functions.